### PR TITLE
Feat: Implement core Turbix functionality and initial UI

### DIFF
--- a/app/src/main/java/io/sensify/sensor/ui/pages/turbix/TurbixViewModel.kt
+++ b/app/src/main/java/io/sensify/sensor/ui/pages/turbix/TurbixViewModel.kt
@@ -1,0 +1,130 @@
+package io.sensify.sensor.ui.pages.turbix
+
+import android.app.Application
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.turbix.turbulenceengine.TurbulenceEngine
+import com.turbix.turbulenceengine.TurbixOutputState
+import io.sensify.sensor.domains.sensors.packets.ModelSensorPacket
+import io.sensify.sensor.domains.sensors.packets.SensorPacketConfig
+import io.sensify.sensor.domains.sensors.packets.SensorPacketsProvider
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlin.math.abs // Ensure abs is imported
+
+class TurbixViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val turbulenceEngine = TurbulenceEngine()
+    val uiState: StateFlow<TurbixOutputState> = turbulenceEngine.outputState
+
+    private var lastTimestampNanos: Long = 0L
+    private var sampleCount: Int = 0
+    private var firstTimestampNanos: Long = 0L
+    private var estimatedFs: Float = 100.0f // Default to 100Hz, PRD suggests 100Hz default
+
+    // Default values for rotor configuration
+    private var currentRpm: Float = 0f // Default to 0 RPM (notch bypassed)
+    private var currentNumBlades: Int = 2 // Default to 2 blades
+
+    init {
+        val accelerometerConfig = SensorPacketConfig(
+            sensorType = Sensor.TYPE_ACCELEROMETER,
+            sensorDelay = SensorManager.SENSOR_DELAY_GAME
+        )
+        SensorPacketsProvider.getInstance().attachSensor(accelerometerConfig)
+
+        // Initial configuration for the engine with default/initial estimatedFs
+        turbulenceEngine.setRotorConfiguration(currentRpm, currentNumBlades, estimatedFs)
+
+        SensorPacketsProvider.getInstance().mSensorPacketFlow
+            .onEach { packet ->
+                if (packet.type == Sensor.TYPE_ACCELEROMETER) {
+                    processSensorPacket(packet)
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun processSensorPacket(packet: ModelSensorPacket) {
+        val currentTimestampNanos = packet.sensorEvent.timestamp
+        var fsJustUpdated = false
+
+        if (lastTimestampNanos != 0L && currentTimestampNanos > lastTimestampNanos) {
+            sampleCount++
+            if (sampleCount == 1) {
+                firstTimestampNanos = currentTimestampNanos
+            }
+
+            if (sampleCount >= 100) { // Windowed estimation
+                val elapsedTimeNanos = currentTimestampNanos - firstTimestampNanos
+                if (elapsedTimeNanos > 0) {
+                    val newFs = (sampleCount.toFloat() * 1_000_000_000L) / elapsedTimeNanos
+                    if (abs(newFs - estimatedFs) > 1.0f) { // Update if change > 1Hz
+                        estimatedFs = newFs
+                        fsJustUpdated = true
+                    }
+                }
+                sampleCount = 0
+            } else { // Instantaneous estimation
+                val dtNanos = currentTimestampNanos - lastTimestampNanos
+                if (dtNanos > 0) {
+                    val newFs = 1_000_000_000.0f / dtNanos
+                     if (abs(newFs - estimatedFs) > 1.0f) {
+                        estimatedFs = newFs
+                        fsJustUpdated = true
+                    }
+                }
+            }
+        }
+        lastTimestampNanos = currentTimestampNanos
+
+        if (fsJustUpdated) {
+            turbulenceEngine.setRotorConfiguration(currentRpm, currentNumBlades, estimatedFs)
+        }
+
+        if (packet.values.size >= 3) {
+            turbulenceEngine.processAccelerometerData(
+                timestamp = packet.timestamp,
+                x = packet.values[0],
+                y = packet.values[1],
+                z = packet.values[2],
+                fs = estimatedFs
+            )
+        }
+    }
+
+    fun setRotorRpm(rpm: Float) {
+        currentRpm = rpm
+        turbulenceEngine.setRotorConfiguration(currentRpm, currentNumBlades, estimatedFs)
+    }
+
+    fun setNumBlades(blades: Int) {
+        currentNumBlades = blades
+        turbulenceEngine.setRotorConfiguration(currentRpm, currentNumBlades, estimatedFs)
+    }
+
+    fun performTare() {
+        turbulenceEngine.performTare()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        SensorPacketsProvider.getInstance().detachSensor(Sensor.TYPE_ACCELEROMETER)
+        turbulenceEngine.reset()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    class Factory(private val application: Application) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(TurbixViewModel::class.java)) {
+                return TurbixViewModel(application) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 }
 rootProject.name = "SensifyAndroid"
 include ':app'
+include ':turbulence-engine'

--- a/turbulence-engine/build.gradle.kts
+++ b/turbulence-engine/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `java-library`
+    id("org.jetbrains.kotlin.jvm")
+}
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.0")
+}


### PR DESCRIPTION
This commit includes the progress made on developing the Turbix application based on the PRD.

Summary of steps and changes:

1.  **Project Setup & Fork Sync:**
    *   I moved the `turbix-PRD.md` file to a `docs/` directory.

2.  **Create `turbulence-engine` Module:**
    *   I created a new Kotlin JVM library module named `turbulence-engine`.
    *   I set up `build.gradle.kts` for this module.
    *   I created the initial `TurbulenceEngine.kt` file.

3.  **Implement `TurbulenceEngine.kt` (Core Logic - Part 1):**
    *   I defined `TurbixOutputState` data class.
    *   I implemented the main data processing method `processAccelerometerData`.
    *   I added Low-Pass Filter for gravity removal (FR-2) and body magnitude calculation.
    *   I added High-Pass Filter (0.5Hz) to suppress maneuver bias (FR-4).
    *   I implemented a 2-second sliding RMS window to calculate *T*<sub>RMS</sub> (FR-5).
    *   I mapped *T*<sub>RMS</sub> to the 0-10 turbulence scale S (FR-6) based on PRD §7.

4.  **Integrate `TurbulenceEngine` with Application (ViewModel):**
    *   I created `TurbixViewModel.kt`.
    *   I instantiated `TurbulenceEngine` within the ViewModel.
    *   I subscribed to accelerometer data from Sensify's `SensorPacketsProvider`.
    *   I implemented logic to estimate sampling frequency (`fs`).
    *   I passed accelerometer data and `fs` to `TurbulenceEngine`.
    *   I exposed `TurbulenceEngine`'s `outputState` via a `StateFlow`.
    *   I added `turbulence-engine` as a project dependency to the main app.

5.  **Develop Basic UI (Primary Screen - UI-1):**
    *   I created `TurbixMainScreen.kt` Composable.
    *   I displayed the numeric turbulence score (S) and a color-changing bar based on S.
    *   I added debug text for other sensor values (T-RMS, raw accel, etc.).
    *   I integrated `TurbixMainScreen` into the app's navigation graph (`NavDirectionsApp.kt`) and set it as the start destination.

6.  **Implement `TurbulenceEngine.kt` (Core Logic - Part 2 - Notch Filter & Settings):**
    *   I implemented the Adaptive Notch Filter (FR-3) in `TurbulenceEngine`:
        *   I added methods `setRotorConfiguration(rpm, blades, samplingFrequency)`.
        *   Filter coefficients are updated when RPM or blade count changes significantly.
        *   Filter is bypassed if RPM is invalid, setting an `accuracyWarning`.
    *   I implemented TARE functionality (FR-7) in `TurbulenceEngine`:
        *   `performTare()` method captures current *T*<sub>RMS</sub> as an offset.
        *   Offset is subtracted from *T*<sub>RMS</sub> before scaling.
    *   I updated `TurbixViewModel` to:
        *   Call `setRotorConfiguration` on the engine (with defaults for now).
        *   Re-configure engine if estimated sampling frequency changes.
        *   Expose methods `setRotorRpm()`, `setNumBlades()`, and `performTare()` to be used by UI/settings later.

The application now has a functional data processing pipeline from raw accelerometer data to a displayed turbulence score, including advanced filtering (LPF, HPF, Notch) and TARE capability. The basic UI shows this score. The next step is to build the settings UI to allow you to configure RPM, blade count, and sample rate.